### PR TITLE
Remove horrible monkey-patching

### DIFF
--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -17,8 +17,7 @@
 \*───────────────────────────────────────────────────────────────────────────*/
 'use strict';
 
-var fs = require('graceful-fs'),
-    path = require('path'),
+var path = require('path'),
     util = require('./util'),
     assert = require('assert');
 
@@ -41,16 +40,15 @@ var proto = {
      * @returns {*}
      */
     resolve: function (name, locale) {
-        var that, match;
+        var match;
 
         name = name + this._ext;
         locale = util.parseLangTag(locale);
-        that = this;
 
         [locale, this._fallback].every(function walk(locale) {
-            match = that._locate(name, locale);
+            match = this._locate(name, locale);
             return !(match && match.file);
-        });
+        }, this);
 
         return match;
     }

--- a/lib/view/js.js
+++ b/lib/view/js.js
@@ -1,66 +1,90 @@
- /*───────────────────────────────────────────────────────────────────────────*\
-│  Copyright (C) 2013 eBay Software Foundation                                │
-│                                                                             │
-│hh ,'""`.                                                                    │
-│  / _  _ \  Licensed under the Apache License, Version 2.0 (the "License");  │
-│  |(@)(@)|  you may not use this file except in compliance with the License. │
-│  )  __  (  You may obtain a copy of the License at                          │
-│ /,'))((`.\                                                                  │
-│(( ((  )) ))    http://www.apache.org/licenses/LICENSE-2.0                   │
-│ `\ `)(' /'                                                                  │
-│                                                                             │
-│   Unless required by applicable law or agreed to in writing, software       │
-│   distributed under the License is distributed on an "AS IS" BASIS,         │
-│   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  │
-│   See the License for the specific language governing permissions and       │
-│   limitations under the License.                                            │
-\*───────────────────────────────────────────────────────────────────────────*/
+/*───────────────────────────────────────────────────────────────────────────*\
+ │  Copyright (C) 2013 eBay Software Foundation                                │
+ │                                                                             │
+ │hh ,'""`.                                                                    │
+ │  / _  _ \  Licensed under the Apache License, Version 2.0 (the "License");  │
+ │  |(@)(@)|  you may not use this file except in compliance with the License. │
+ │  )  __  (  You may obtain a copy of the License at                          │
+ │ /,'))((`.\                                                                  │
+ │(( ((  )) ))    http://www.apache.org/licenses/LICENSE-2.0                   │
+ │ `\ `)(' /'                                                                  │
+ │                                                                             │
+ │   Unless required by applicable law or agreed to in writing, software       │
+ │   distributed under the License is distributed on an "AS IS" BASIS,         │
+ │   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  │
+ │   See the License for the specific language governing permissions and       │
+ │   limitations under the License.                                            │
+ \*───────────────────────────────────────────────────────────────────────────*/
 'use strict';
 
-var fs = require('graceful-fs'),
-    path = require('path'),
-    resolverFactory = require('../resolver');
+var path = require('path'),
+    fs = require('graceful-fs'),
+    resolver = require('../resolver');
 
-exports.create = function (app, translator) {
-    var views, resolver, render;
 
-    views = app.get('views');
-    resolver = resolverFactory.create({ root: views, ext: 'js', fallback: translator.fallbackLocale });
+var proto = {
 
-    if (app.render.name !== 'clobbered') {
-        // XXX - This is an awful hack.
-        render = app.render;
-        app.render = function clobbered(view, options, fn) {
-            var locals, templateInfo;
+    get path() {
+        // Unfortunately, since we don't know the actual file to resolve until
+        // we get request context (in `render`), we can't say whether it exists or not.
+        return true;
+    },
 
-            // Reset root
-            app.set('views', views);
+    render: function (options, callback) {
+        var locals, view, engine;
 
-            locals = options._locals &&  options._locals.context;
-            templateInfo = resolver.resolve(view, locals && locals.locality);
+        locals = options && options.context;
+        view = this.resolver.resolve(this.name, locals && locals.locality);
 
-            if (templateInfo.root) {
-                // We update the view root *only* for the call to app.render.
-                // It only works because the part that resolves the view path is synchronous
-                // and once we get past that check our own code can take over.
-                app.set('views', templateInfo.root);
-            }
+        // This is a bit of a hack to ensure we override `views` for the duration
+        // of the rendering lifecycle. Unfortunately, `adaro` and `consolidate`
+        // (https://github.com/visionmedia/consolidate.js/blob/407266806f3a713240db2285527de934be7a8019/lib/consolidate.js#L214)
+        // check `options.views` but override with `options.settings.views` if available.
+        // So, for this rendering task we need to override with the more specific root directory.
+        options.settings = Object.create(options.settings);
+        options.views = options.settings.views = view.root;
 
-            render.apply(this, arguments);
-        };
+        engine = this.engines['.' + this.defaultEngine];
+        engine(view.file, options, callback);
     }
 
+};
+
+
+function buildCtor(fallback) {
+
+    function View(name, options) {
+        this.name = name;
+        this.root = options.root;
+        this.defaultEngine = options.defaultEngine;
+        this.engines = options.engines;
+        this.resolver = resolver.create({ root: options.root, ext: this.defaultEngine, fallback: fallback });
+    }
+
+    View.prototype = proto;
+
+    return View;
+
+}
+
+
+exports.create = function (app, translator) {
+    var res;
+
+    res = resolver.create({ root: app.get('views'), ext: app.get('view engine'), fallback: translator.fallbackLocale });
+    app.set('view', buildCtor(translator.fallbackLocale));
+
     return function onLoad(name, context, callback) {
-        var locals, templateInfo;
+        var locals, view;
 
         locals = context.get('context');
-        templateInfo = resolver.resolve(name, locals && locals.locality);
+        view = res.resolve(name, locals && locals.locality);
 
-        if (!templateInfo.file) {
+        if (!view.file) {
             callback(new Error('Could not load template ' + name));
             return;
         }
 
-        fs.readFile(templateInfo.file, 'utf8', callback);
+        fs.readFile(view.file, 'utf8', callback);
     };
 };

--- a/test/i18n.js
+++ b/test/i18n.js
@@ -21,7 +21,7 @@ describe('i18n', function () {
 
     var config;
 
-    var app, engine, server, render;
+    var app, engine, server;
 
     before(function (next) {
         // Ensure the test case assumes it's being run from application root.
@@ -50,7 +50,6 @@ describe('i18n', function () {
 
         engine = dustjs;
         server = app.listen(8000, next);
-        render = app.render;
     });
 
 
@@ -71,9 +70,7 @@ describe('i18n', function () {
 
 
         after(function () {
-            app.render = render;
             engine.onLoad = undefined;
-            //i18n.cache.reset();
         });
 
 
@@ -201,9 +198,7 @@ describe('i18n', function () {
 
 
         after(function () {
-            app.render = render;
             engine.onLoad = undefined;
-            //i18n.cache.reset();
         });
 
 
@@ -242,10 +237,8 @@ describe('i18n', function () {
 
 
         after(function () {
-            app.render = render;
             engine.onLoad = undefined;
             config.cache = false;
-            //i18n.cache.reset();
         });
 
 


### PR DESCRIPTION
Previously, a horrible monkey-patched hack was used to deal with resolving the location of localized templates. This PR removes the monkey patching, substituting a custom `View` implementation/resolver. `lib/view/js.js` was mostly rewritten, so a careful review of the code in its current state (as opposed to a diff) would be extremely helpful.
