### PR TITLE
Added escape character to system path separator. Fixes #16

### DIFF
--- a/tasks/dustjs-i18n.js
+++ b/tasks/dustjs-i18n.js
@@ -55,7 +55,7 @@ module.exports = function (grunt) {
         }
 
         contentPath = contentPath.map(function (cp) {
-            var regexp = new RegExp('([' + path.sep + ']?)$');
+            var regexp = new RegExp('([\\' + path.sep + ']?)$');
             if (!endsWith(cp, pathName)) {
                 return cp.replace(regexp, pathName);
             }


### PR DESCRIPTION
I know that we need to add tests to prove our changes works, 
But in this particular scenario, the tests won't load without this fix.

It's simple, but even the simplest RegExp needs a bunch of eyeballs on it.
