### PR TITLE
Modify dustjs-linkedin peerDependency to work until v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "grunt-simple-mocha": "~0.4.0",
     "grunt-contrib-clean": "~0.4.1",
     "grunt-contrib-jshint": "~0.6.0",
-    "dustjs-linkedin": "~2.0.0",
+    "dustjs-linkedin": "^2.0.0",
     "dustjs-helpers": "~1.1.1",
     "adaro": "~0.1.4"
   },


### PR DESCRIPTION
This pull request resolves https://github.com/paypal/makara/issues/24
