### PR TITLE
Use `he` for robust HTML entity encoding/decoding

### DIFF
--- a/lib/provider/metadata.js
+++ b/lib/provider/metadata.js
@@ -19,7 +19,7 @@
 'use strict';
 
 var util = require('util'),
-    ent = require('ent');
+    he = require('he');
 
 
 var ANNOTATION = '<edit data-key="%s" data-bundle="%s" data-original="%s">%s</edit>';
@@ -82,7 +82,7 @@ exports.decorate = function (bundle) {
         },
 
         _encode: function (str) {
-            str = ent.encode(str || '');
+            str = he.encode(str || '');
             return str.split('').map(function (chr) {
                 return CHAR_MAP[chr] || chr;
             }).join('');

--- a/package.json
+++ b/package.json
@@ -69,10 +69,10 @@
   },
   "dependencies": {
     "findatag": "~0.0.8",
-    "ent": "0.0.5",
+    "graceful-fs": "~2.0.1",
+    "he": "~0.4.1",
     "q": "~0.9.6",
-    "spud": "~0.0.2",
-    "graceful-fs": "~2.0.1"
+    "spud": "~0.0.2"
   },
   "peerDependencies": {
     "dustjs-linkedin": "^2.0.0",


### PR DESCRIPTION
_ent_ has [several open issues](https://github.com/substack/node-ent/issues/created_by/mathiasbynens?state=open) that are not present in [_he_](http://mths.be/he).
